### PR TITLE
Fixed square gradient sizes; formatted link bkgds in #Home

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -20,7 +20,7 @@ a {font-weight: bold; color: black;}
 /* *******   Landing section: #Home    ********** */
 
 #Home {
-    --darkest: #883333;
+    --darkest: #88333388;
     --darker: #FF8888;
     --lighter: #FF888888;
     background-image: 
@@ -33,8 +33,8 @@ a {font-weight: bold; color: black;}
         linear-gradient(
             to right,
             var(--darkest),
-            transparent 7vh,
-            transparent 93vh,
+            transparent 7vw,
+            transparent 90vw,
             var(--darkest)
         ),
         linear-gradient(
@@ -90,12 +90,15 @@ h1 {
     font-family: Cambria, Cochin, Georgia, Times, 'Times New Roman', serif;
     font-style: italic;
     margin: 5rem auto;
+    padding: 0 15vw;
 
 }
 
 #Home a {
     background-color: #FFFFFF55;
+    padding: 0.2rem;
     border-radius: 5px;
+    box-shadow: 0 0 8px white;
 }
 
 /* *******  Plaid section  ********** */
@@ -166,8 +169,8 @@ h1 {
         linear-gradient(
             to right,
             #91d9edFF,
-            #91d9ed88 7vh,
-            #91d9ed88 93vh,
+            #91d9ed88 7vw,
+            #91d9ed88 90vw,
             #91d9edFF
         )
     ;
@@ -265,7 +268,7 @@ h1 {
 }
 
 .irid {
-    width: 50%;
+    width: 70%;
     height: 100%;
     position: absolute;
     opacity: 0;


### PR DESCRIPTION
Link bkgds in #Home now have padding and a drop-shadow. Quite pretty. More importantly, the too-wide gradient down the right side of the screen was fixed in #Home and #TransparentCircles; the problem was that I was defining the to-right gradients in viewheight units instead of viewwidth units.